### PR TITLE
SF: Bring back support for disabling backpressure propagation

### DIFF
--- a/services/surfaceflinger/Scheduler/include/scheduler/Features.h
+++ b/services/surfaceflinger/Scheduler/include/scheduler/Features.h
@@ -30,6 +30,7 @@ enum class Feature : std::uint8_t {
     kBackpressureGpuComposition = 1 << 4,
     kSmallDirtyContentDetection = 1 << 5,
     kExpectedPresentTime = 1 << 6,
+    kPropagateBackpressure = 1 << 7,
 };
 
 using FeatureFlags = ftl::Flags<Feature>;

--- a/services/surfaceflinger/Scheduler/include/scheduler/FrameTargeter.h
+++ b/services/surfaceflinger/Scheduler/include/scheduler/FrameTargeter.h
@@ -125,7 +125,8 @@ public:
     FrameTargeter(PhysicalDisplayId displayId, FeatureFlags flags)
           : FrameTarget(to_string(displayId)),
             mBackpressureGpuComposition(flags.test(Feature::kBackpressureGpuComposition)),
-            mSupportsExpectedPresentTime(flags.test(Feature::kExpectedPresentTime)) {}
+            mSupportsExpectedPresentTime(flags.test(Feature::kExpectedPresentTime)),
+            mPropagateBackpressure(flags.test(Feature::kPropagateBackpressure)) {}
 
     const FrameTarget& target() const { return *this; }
 
@@ -161,6 +162,7 @@ private:
 
     const bool mBackpressureGpuComposition;
     const bool mSupportsExpectedPresentTime;
+    const bool mPropagateBackpressure;
 
     TimePoint mScheduledPresentTime;
     CompositionCoverageFlags mCompositionCoverage;

--- a/services/surfaceflinger/Scheduler/src/FrameTargeter.cpp
+++ b/services/surfaceflinger/Scheduler/src/FrameTargeter.cpp
@@ -127,14 +127,14 @@ void FrameTargeter::beginFrame(const BeginFrameArgs& args, const IVsyncSource& v
                 mBackpressureGpuComposition || !mCompositionCoverage.test(CompositionCoverage::Gpu);
 
         if (!FlagManager::getInstance().allow_n_vsyncs_in_targeter()) {
-            return static_cast<int>(considerBackpressure);
+            return mPropagateBackpressure && static_cast<int>(considerBackpressure);
         }
 
         if (!wouldBackpressure || !considerBackpressure) {
-            return 0;
+            return false;
         }
 
-        return static_cast<int>((std::abs(fence.expectedPresentTime.ns() - mFrameBeginTime.ns()) <=
+        return mPropagateBackpressure && static_cast<int>((std::abs(fence.expectedPresentTime.ns() - mFrameBeginTime.ns()) <=
                                  Duration(1ms).ns()));
     }();
 

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -484,6 +484,10 @@ SurfaceFlinger::SurfaceFlinger(Factory& factory) : SurfaceFlinger(factory, SkipI
 
     mDebugFlashDelay = base::GetUintProperty("debug.sf.showupdates"s, 0u);
 
+    property_get("debug.sf.disable_backpressure", value, "0");
+    mPropagateBackpressure = !atoi(value);
+    ALOGI_IF(!mPropagateBackpressure, "Disabling backpressure propagation");
+
     mBackpressureGpuComposition = base::GetBoolProperty("debug.sf.enable_gl_backpressure"s, true);
     ALOGI_IF(mBackpressureGpuComposition, "Enabling backpressure for GPU composition");
 
@@ -2593,7 +2597,7 @@ bool SurfaceFlinger::commit(PhysicalDisplayId pacesetterId,
     }
 
     if (pacesetterFrameTarget.wouldBackpressureHwc()) {
-        if (mBackpressureGpuComposition || pacesetterFrameTarget.didMissHwcFrame()) {
+        if (mPropagateBackpressure && (mBackpressureGpuComposition || pacesetterFrameTarget.didMissHwcFrame())) {
             if (FlagManager::getInstance().vrr_config()) {
                 mScheduler->getVsyncSchedule()->getTracker().onFrameMissed(
                         pacesetterFrameTarget.expectedPresentTime());
@@ -4332,6 +4336,9 @@ void SurfaceFlinger::initScheduler(const sp<const DisplayDevice>& display) {
     }
     if (mBackpressureGpuComposition) {
         features |= Feature::kBackpressureGpuComposition;
+    }
+    if (mPropagateBackpressure) {
+        features |= Feature::kPropagateBackpressure;
     }
     if (getHwComposer().getComposer()->isSupported(
                 Hwc2::Composer::OptionalFeature::ExpectedPresentTime)) {

--- a/services/surfaceflinger/SurfaceFlinger.h
+++ b/services/surfaceflinger/SurfaceFlinger.h
@@ -1293,6 +1293,7 @@ private:
     std::atomic_bool mForceFullDamage = false;
 
     bool mLayerCachingEnabled = false;
+    bool mPropagateBackpressure = true;
     bool mBackpressureGpuComposition = false;
 
     LayerTracing mLayerTracing;


### PR DESCRIPTION
[Pulkit077]: Adapt to A14 QPR1
[SamarV-121]: Adapt to A14 QPR3
[Flakeforever]: Adapt to Evolution-X A15 QPR1

Taken from CLO (QSSI 13). Some Qualcomm devices can still benefit from disabling backpressure propagation by setting:

debug.sf.disable_backpressure=1

Change-Id: I669a6059a2a971aa79603e74153fa93729f703dc