### PR TITLE
[MiuiCamera] Native: ProducerListener: Import ON_BUFFER_DETACHED Changes for QPR1

### DIFF
--- a/libs/gui/IProducerListener.cpp
+++ b/libs/gui/IProducerListener.cpp
@@ -123,6 +123,10 @@ public:
     virtual void onBuffersDiscarded(const std::vector<int32_t>& discardedSlots) override {
         return mBase->onBuffersDiscarded(discardedSlots);
     }
+
+    virtual void onBufferDetached(int slot) {
+        mBase->onBufferDetached(slot);
+    }
 };
 
 IMPLEMENT_HYBRID_META_INTERFACE(ProducerListener,
@@ -190,4 +194,7 @@ bool BnProducerListener::needsAttachNotify() {
 }
 #endif
 
+void BnProducerListener::onBufferDetached(int slot) {
+    ALOGE("BnProducerListener::onBufferDetached slot: %d",slot);
+}
 } // namespace android

--- a/libs/gui/bufferqueue/1.0/WProducerListener.cpp
+++ b/libs/gui/bufferqueue/1.0/WProducerListener.cpp
@@ -49,4 +49,7 @@ bool LWProducerListener::needsReleaseNotify() {
 void LWProducerListener::onBuffersDiscarded(const std::vector<int32_t>& /*slots*/) {
 }
 
+void LWProducerListener::onBufferDetached(int /*slot*/) {
+}
+
 }  // namespace android

--- a/libs/gui/bufferqueue/2.0/H2BProducerListener.cpp
+++ b/libs/gui/bufferqueue/2.0/H2BProducerListener.cpp
@@ -55,6 +55,9 @@ bool H2BProducerListener::needsReleaseNotify() {
 void H2BProducerListener::onBuffersDiscarded(const std::vector<int32_t>& /*slots*/) {
 }
 
+void H2BProducerListener::onBufferDetached(int /*slot*/) {
+}
+
 }  // namespace utils
 }  // namespace V2_0
 }  // namespace bufferqueue

--- a/libs/gui/include/gui/IProducerListener.h
+++ b/libs/gui/include/gui/IProducerListener.h
@@ -90,6 +90,7 @@ public:
             Parcel* reply, uint32_t flags = 0);
     virtual bool needsReleaseNotify();
     virtual void onBuffersDiscarded(const std::vector<int32_t>& slots);
+    virtual void onBufferDetached(int slot);
 #if COM_ANDROID_GRAPHICS_LIBGUI_FLAGS(BQ_CONSUMER_ATTACH_CALLBACK)
     virtual bool needsAttachNotify();
 #endif
@@ -106,6 +107,7 @@ public:
     virtual ~StubProducerListener();
     virtual void onBufferReleased() {}
     virtual bool needsReleaseNotify() { return false; }
+    virtual void onBufferDetached(int /**slot**/) {}
 #if COM_ANDROID_GRAPHICS_LIBGUI_FLAGS(BQ_CONSUMER_ATTACH_CALLBACK)
     virtual bool needsAttachNotify() { return false; }
 #endif

--- a/libs/gui/include/gui/bufferqueue/1.0/WProducerListener.h
+++ b/libs/gui/include/gui/bufferqueue/1.0/WProducerListener.h
@@ -55,6 +55,7 @@ public:
     void onBufferReleased() override;
     bool needsReleaseNotify() override;
     void onBuffersDiscarded(const std::vector<int32_t>& slots) override;
+    void onBufferDetached(int slot) override;
 };
 
 }  // namespace android

--- a/libs/gui/include/gui/bufferqueue/2.0/H2BProducerListener.h
+++ b/libs/gui/include/gui/bufferqueue/2.0/H2BProducerListener.h
@@ -47,6 +47,7 @@ public:
     virtual void onBufferReleased() override;
     virtual bool needsReleaseNotify() override;
     virtual void onBuffersDiscarded(const std::vector<int32_t>& slots) override;
+    virtual void onBufferDetached(int slot) override;
 };
 
 }  // namespace utils


### PR DESCRIPTION
- Miui Camera requires it E CAM_MiCamAlgoInterfaceJNI: can not load library:camera_algoup_jni.xiaomi : java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "_ZN7android18BnProducerListener16onBufferDetachedEi" referenced by "/system/lib64/libcamera_algoup_jni.xiaomi.so"...

- Adapted for A15 QPR-1